### PR TITLE
Fix average interval for '1week', '1month', and '1year'

### DIFF
--- a/R/get_sensor_history.R
+++ b/R/get_sensor_history.R
@@ -35,7 +35,7 @@ get_sensor_history <- function(sensor_index,
   avg_int <- as.integer(
     c(
       "real-time" = 0, "10min" = 10, "30min" = 30, "60min" = 60,
-      "6hr" = 360, "1day" = 1440, "1week" = 60, "1month" = 60, "1year" = 60
+      "6hr" = 360, "1day" = 1440, "1week" = 10800, "1month" = 43200, "1year" = 525600
     )[avg]
   )
   resp <-


### PR DESCRIPTION
adjusted the endpoints for the intervals to ensure that they pull from the correct endpoint and don't overrun return quotas