### PR TITLE
Drop malformed rows from sensor history responses and add parsing tests

### DIFF
--- a/R/get_sensor_history.R
+++ b/R/get_sensor_history.R
@@ -49,12 +49,33 @@ get_sensor_history <- function(sensor_index,
     ) |>
     httr2::req_perform() |>
     httr2::resp_body_json()
+  return(parse_sensor_history_response(resp))
+  ## md <- purrr::discard_at(resp, c("fields", "data"))
+}
+
+parse_sensor_history_response <- function(resp) {
+  expected_n_fields <- length(resp$fields)
+  row_lengths <- purrr::map_int(resp$data, length)
+  invalid_row_idx <- which(row_lengths != expected_n_fields)
+
+  if (length(invalid_row_idx) > 0) {
+    cli::cli_warn(c(
+      "PurpleAir history response included malformed rows; dropping them.",
+      "i" = "Dropped {length(invalid_row_idx)} row(s) where value count differed from field count ({expected_n_fields})."
+    ))
+  }
+
+  valid_rows <- resp$data[row_lengths == expected_n_fields]
+
+  if (length(valid_rows) == 0) {
+    return(tibble::as_tibble(stats::setNames(rep(list(numeric(0)), expected_n_fields), resp$fields)))
+  }
+
   out <-
-    purrr::map(resp$data, stats::setNames, resp$fields) |>
+    purrr::map(valid_rows, stats::setNames, resp$fields) |>
     purrr::modify(as.data.frame) |>
     purrr::list_rbind() |>
     tibble::as_tibble()
   out$time_stamp <- as.POSIXct.numeric(out$time_stamp)
   return(out)
-  ## md <- purrr::discard_at(resp, c("fields", "data"))
 }

--- a/tests/testthat/test-get_sensor_history.R
+++ b/tests/testthat/test-get_sensor_history.R
@@ -11,3 +11,42 @@ test_that("get_sensor_history works", {
   ) |>
     expect_s3_class("tbl_df")
 })
+
+test_that("parse_sensor_history_response drops malformed rows", {
+  resp <- list(
+    fields = c("time_stamp", "pm2.5_atm"),
+    data = list(
+      list(1700000000, 5.1),
+      list(1700000600),
+      list(1700001200, 5.8)
+    )
+  )
+
+  expect_warning(
+    out <- parse_sensor_history_response(resp),
+    "malformed rows"
+  )
+
+  expect_s3_class(out, "tbl_df")
+  expect_equal(nrow(out), 2)
+  expect_equal(names(out), c("time_stamp", "pm2.5_atm"))
+})
+
+test_that("parse_sensor_history_response returns empty tibble when all rows are malformed", {
+  resp <- list(
+    fields = c("time_stamp", "pm2.5_atm"),
+    data = list(
+      list(1700000000),
+      list(1700000600)
+    )
+  )
+
+  expect_warning(
+    out <- parse_sensor_history_response(resp),
+    "malformed rows"
+  )
+
+  expect_s3_class(out, "tbl_df")
+  expect_equal(nrow(out), 0)
+  expect_equal(names(out), c("time_stamp", "pm2.5_atm"))
+})


### PR DESCRIPTION
### Motivation

- The PurpleAir `sensor_history` response can include rows where the number of values does not match the `fields` count, which breaks downstream binding and conversion.

### Description

- Added a new helper `parse_sensor_history_response` that validates row lengths against `resp$fields`, drops malformed rows, and emits a `cli::cli_warn` when any are removed.
- Updated `get_sensor_history` to call `parse_sensor_history_response` on the API response and return a cleaned tibble with `time_stamp` converted to `POSIXct` as before.
- When all rows are malformed the parser returns an empty tibble with the expected column names instead of failing.

### Testing

- Existing integration test `get_sensor_history works` remains and is executed only off CRAN and on supported OSes as before and passed during the test run.
- Added unit tests for `parse_sensor_history_response` that assert malformed rows generate a warning, dropped rows are removed, and an empty tibble with correct columns is returned when all rows are malformed, and these tests passed under `testthat`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dd9644f238833197725bf17702f92b)